### PR TITLE
Mkaito/bump elixir

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -44,6 +44,11 @@ let
         # BEAM-based languages.
         elixir = elixir_1_7;
 
+        elixir_1_8 = lib.callElixir ../interpreters/elixir/1.8.nix {
+          inherit rebar erlang;
+          debugInfo = true;
+        };
+
         elixir_1_7 = lib.callElixir ../interpreters/elixir/1.7.nix {
           inherit rebar erlang;
           debugInfo = true;

--- a/pkgs/development/interpreters/elixir/1.8.nix
+++ b/pkgs/development/interpreters/elixir/1.8.nix
@@ -1,0 +1,7 @@
+{ mkDerivation }:
+
+mkDerivation rec {
+  version = "1.8.0-rc.1";
+  sha256 = "06k9q46cwn79ic6kw0b0mskf9rqlgm02jb8n1ajz55kmw134kq6m";
+  minimumOTPVersion = "20";
+}

--- a/pkgs/development/interpreters/elixir/1.8.nix
+++ b/pkgs/development/interpreters/elixir/1.8.nix
@@ -1,7 +1,7 @@
 { mkDerivation }:
 
 mkDerivation rec {
-  version = "1.8.0-rc.1";
-  sha256 = "06k9q46cwn79ic6kw0b0mskf9rqlgm02jb8n1ajz55kmw134kq6m";
+  version = "1.8.1";
+  sha256 = "1npnrkn21kqqfqrsn06mr78jxs6n5l8c935jpxvnmj7iysp50pf9";
   minimumOTPVersion = "20";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7624,7 +7624,7 @@ with pkgs;
   inherit (beam.interpreters)
     erlang erlangR18 erlangR19 erlangR20 erlangR21
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
-    elixir elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3
+    elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3
     lfe lfe_1_2;
 
   inherit (beam.packages.erlang)

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -61,7 +61,8 @@ rec {
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR19.elixir`.
-    inherit (packages.erlang) elixir elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3;
+    inherit (packages.erlang)
+      elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3;
 
     inherit (packages.erlang) lfe lfe_1_2;
   };


### PR DESCRIPTION
###### Motivation for this change
Get Elixir 1.8
###### Things done
Cherry picked 4345715025d618689edeb66dfa1f33557d426a20 and 2407326fd91ee5fe36e7238f390f826e14e51ab2 from upstream.

```
~/dev/serokell/nixpkgs mkaito/bump-elixir 40s
❯ nix-build -A elixir_1_8
.........
/nix/store/8fi57w029ds7yrmc7vipkx9m63hny1dm-elixir-1.8.1

~/dev/serokell/nixpkgs mkaito/bump-elixir 40s
❯ result/bin/elixir --version
Erlang/OTP 20 [erts-9.3.3.3] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:10] [hipe] [kernel-poll:false]

Elixir 1.8.1 (compiled with Erlang/OTP 20)
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
