### PR TITLE
[OPS-811] Fix servant-client-core != 0.15

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -490,7 +490,15 @@ self: super: builtins.intersectAttrs super {
   servant-streaming-server = dontCheck super.servant-streaming-server;
 
   # https://github.com/haskell-servant/servant/pull/1128
-  servant-client-core = appendPatch super.servant-client-core ./patches/servant-client-core-streamBody.patch;
+  servant-client-core = let
+    inherit (pkgs.lib) getVersion versionOlder versionAtLeast;
+    scc = super.servant-client-core;
+    v = getVersion scc;
+  in if versionOlder v "0.16" && versionAtLeast v "0.15" then
+    appendPatch scc ./patches/servant-client-core-streamBody.patch
+  else
+    scc;
+
 
   # tests run executable, relying on PATH
   # without this, tests fail with "Couldn't launch intero process"


### PR DESCRIPTION
###### Motivation for this change
A patch was added unconditionally that only applies to 0.15, breaking
builds of 0.14.


###### Things done
Apply patch only if version is 0.15.*

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

