### PR TITLE
[AG-26] Patch some Docker modules

### DIFF
--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -172,7 +172,7 @@ let
       ExecStart = concatStringsSep " \\\n  " ([
         "${pkgs.docker}/bin/docker run"
         "--rm"
-        "--name=%n"
+        "--name=${name}"
         "--log-driver=${container.log-driver}"
       ] ++ optional (container.entrypoint != null)
         "--entrypoint=${escapeShellArg container.entrypoint}"
@@ -185,9 +185,9 @@ let
         ++ [container.image]
         ++ map escapeShellArg container.cmd
       );
-      ExecStartPre = "-${pkgs.docker}/bin/docker rm -f %n";
-      ExecStop = "${pkgs.docker}/bin/docker stop %n";
-      ExecStopPost = "-${pkgs.docker}/bin/docker rm -f %n";
+      ExecStartPre = "-${pkgs.docker}/bin/docker rm -f ${name}";
+      ExecStop = "${pkgs.docker}/bin/docker stop ${name}";
+      ExecStopPost = "-${pkgs.docker}/bin/docker rm -f ${name}";
 
       ### There is no generalized way of supporting `reload` for docker
       ### containers. Some containers may respond well to SIGHUP sent to their

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -9,6 +9,67 @@ let
   cfg = config.virtualisation.docker;
   proxy_env = config.networking.proxy.envVars;
 
+  inherit (builtins) attrNames;
+
+  mkUncreateMaybe = networks: volumes: ''
+    set -euo pipefail
+
+    nexisting=$(${pkgs.coreutils}/bin/mktemp)
+    nwanted=$(${pkgs.coreutils}/bin/mktemp)
+    vexisting=$(${pkgs.coreutils}/bin/mktemp)
+    vwanted=$(${pkgs.coreutils}/bin/mktemp)
+
+    cleanup() {
+      rm -f "$nexisting" "$nwanted" "$vexisting" "$vwanted"
+    }
+    trap cleanup EXIT
+
+    ${pkgs.docker}/bin/docker network ls --format '{{.Name}}' > "$nexisting"
+    echo -e "bridge\nhost\nnone\n${concatStringsSep "\n" networks}" > "$nwanted"
+
+    ${pkgs.docker}/bin/docker volume ls --format '{{.Name}}' > "$vexisting"
+    echo -e "${concatStringsSep "\n" volumes}" > "$vwanted"
+
+    nsuperfluous="$(${pkgs.gnugrep}/bin/grep -vxF -f $nwanted $nexisting || true)"
+    vsuperfluous="$(${pkgs.gnugrep}/bin/grep -vxF -f $vwanted $vexisting || true)"
+
+    while read -r net; do
+      if [[ ! -z "$net" ]]; then
+        echo -n "Removed superfluous Docker network: "
+        ${pkgs.docker}/bin/docker network rm "$net"
+      fi
+    done <<< "$nsuperfluous"
+
+    while read -r vol; do
+      if [[ ! -z "$vol" ]]; then
+        echo -n "Removed superfluous Docker volume: "
+        ${pkgs.docker}/bin/docker volume rm "$vol"
+      fi
+    done <<< "$vsuperfluous"
+  '';
+
+  mkNetworkOpts = opts: concatStringsSep " "
+    ([ "--driver=${opts.driver}" ]
+    ++ optional (cfg ? subnet && cfg.subnet != null) "--subnet=${opts.subnet}"
+    ++ optional (cfg ? ip-range && cfg.ip-range != null) "--ip-range=${opts.ip-range}"
+    ++ optional (cfg ? gateway && cfg.gateway != null) "--gateway=${opts.gateway}"
+    ++ optional (cfg ? ipv6 && cfg.ipv6) "--ipv6"
+    ++ optional (cfg ? internal && cfg.internal) "--internal");
+
+
+  mkNetwork = name: opts: ''
+    if [[ $(${pkgs.docker}/bin/docker network ls --quiet --filter name=${name} | wc -c) -eq 0 ]]; then
+      echo "*** docker network create ${mkNetworkOpts opts} ${name}"
+      ${pkgs.docker}/bin/docker network create ${mkNetworkOpts opts} ${name}
+    fi
+  '';
+
+  mkVolume = name: ''
+    if [[ $(${pkgs.docker}/bin/docker volume ls --quiet --filter name=${name} | wc -c) -eq 0 ]]; then
+      echo "*** docker volume create ${name}"
+      ${pkgs.docker}/bin/docker volume create ${name}
+    fi
+  '';
 in
 
 {
@@ -93,6 +154,16 @@ in
           '';
       };
 
+    logLevel =
+      mkOption {
+        type = types.enum ["debug" "info" "warn" "error" "fatal"];
+        default = "info";
+        description =
+          ''
+            This option determines the log level for the Docker daemon.
+          '';
+      };
+
     extraOptions =
       mkOption {
         type = types.separatedString " ";
@@ -144,6 +215,90 @@ in
         Docker package to be used in the module.
       '';
     };
+
+    volumes = mkOption {
+      default = [];
+      type = types.listOf types.str;
+      example = [ "volume_1" "volume_2" ];
+      description = ''
+        A list of named volumes that should be created.
+      '';
+    };
+
+
+    networks = mkOption {
+      default = {};
+      type = types.attrsOf (types.submodule {
+        options = {
+          driver = mkOption {
+            default = "bridge";
+            type = types.str;
+            example = "overlay";
+            description = ''
+              Driver to manage the network. One of bridge, or overlay.
+            '';
+          };
+
+          subnet = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            example = "172.28.0.0/16";
+            description = ''
+              Subnet in CIDR format that represents a network segment.
+            '';
+          };
+
+          ip-range = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            example = "172.28.5.0/24";
+            description = ''
+              Allocate container ip from a sub-range.
+            '';
+          };
+
+          gateway = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            example = "172.28.5.254";
+            description = ''
+              IPv4 or IPv6 Gateway for the master subnet.
+            '';
+          };
+
+          ipv6 = mkOption {
+            default = false;
+            type = types.bool;
+            example = true;
+            description = ''
+              Enable IPv6 networking.
+            '';
+          };
+
+          internal = mkOption {
+            default = false;
+            type = types.bool;
+            example = true;
+            description = ''
+              Restrict external access to the network.
+            '';
+          };
+        };
+      });
+
+      example = {
+        my-network = {
+          driver = "bridge";
+          subnet = "172.28.0.0/16";
+          ip-range = "172.28.5.0/24";
+          gateway = "172.28.5.254";
+        };
+      };
+
+      description = ''
+        A list of named networks to be created.
+      '';
+    };
   };
 
   ###### implementation
@@ -157,6 +312,11 @@ in
       systemd.services.docker = {
         wantedBy = optional cfg.enableOnBoot "multi-user.target";
         environment = proxy_env;
+
+        postStart = mkUncreateMaybe (attrNames cfg.networks) cfg.volumes
+                  + concatStrings (mapAttrsToList mkNetwork cfg.networks)
+                  + concatStrings (map mkVolume cfg.volumes);
+
         serviceConfig = {
           ExecStart = [
             ""
@@ -165,11 +325,13 @@ in
                 --group=docker \
                 --host=fd:// \
                 --log-driver=${cfg.logDriver} \
+                --log-level=${cfg.logLevel} \
                 ${optionalString (cfg.storageDriver != null) "--storage-driver=${cfg.storageDriver}"} \
                 ${optionalString cfg.liveRestore "--live-restore" } \
                 ${optionalString cfg.enableNvidia "--add-runtime nvidia=${pkgs.nvidia-docker}/bin/nvidia-container-runtime" } \
                 ${cfg.extraOptions}
             ''];
+
           ExecReload=[
             ""
             "${pkgs.procps}/bin/kill -s HUP $MAINPID"

--- a/nixos/tests/docker.nix
+++ b/nixos/tests/docker.nix
@@ -10,8 +10,19 @@ import ./make-test.nix ({ pkgs, ...} : {
     docker =
       { pkgs, ... }:
         {
-          virtualisation.docker.enable = true;
-          virtualisation.docker.package = pkgs.docker;
+          virtualisation.docker = {
+            enable = true;
+            package = pkgs.docker;
+            volumes = [ "thevolume" ];
+            networks.thenetwork = {
+              driver = "bridge";
+              subnet = "172.28.0.0/16";
+              ip-range = "172.28.5.0/24";
+              gateway = "172.28.5.254";
+            };
+
+            logLevel = "warn";
+          };
 
           users.users = {
             noprivs = {
@@ -40,6 +51,15 @@ import ./make-test.nix ({ pkgs, ...} : {
     $docker->succeed("sudo -u hasprivs docker ps");
     $docker->fail("sudo -u noprivs docker ps");
     $docker->succeed("docker stop sleeping");
+
+    $docker->succeed("docker volume ls | grep thevolume");
+    $docker->succeed("docker network ls | grep thenetwork");
+
+    $docker->succeed("docker volume create superfluousvolume");
+    $docker->succeed("docker network create superfluousnetwork");
+    $docker->systemctl("restart docker");
+    $docker->waitForUnit("docker.service");
+    $docker->fail("docker volume ls | grep superfluous");
 
     # Must match version twice to ensure client and server versions are correct
     $docker->succeed('[ $(docker version | grep ${pkgs.docker.version} | wc -l) = "2" ]');


### PR DESCRIPTION
###### Motivation for this change
I wanted a way to declaratively make sure certain named Docker volumes and networks exist.

I'm not sure I want this to try and delete networks and volumes when they are removed from the config.

###### Things done
Added:

* `services.docker.volumes`
* `services.docker.networks`

Tested in local VM with Agora config.

Edit: Test it yourself. Now with more NixOS tests:

```sh
$ nix-build -A nixosTests.docker
```

Changed:
`docker-containers.thecontainer = {}` was giving containers names like `docker-thecontainer.service` which is awkward when you want to use Docker's internal name resolution. Calling it simply `thecontainer` seems nicer to work with when configuring internal networking.

Cons: Requires making sure your declarative container names don't clash with any existing imperative container names on the same system.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

