### PR TITLE
Backport from nixos-unstable-small: vault, vault-bin, consul

### DIFF
--- a/pkgs/servers/consul/default.nix
+++ b/pkgs/servers/consul/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "consul-${version}";
-  version = "1.4.1";
+  version = "1.5.2";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/consul";
@@ -19,7 +19,7 @@ buildGoPackage rec {
     owner = "hashicorp";
     repo = "consul";
     inherit rev;
-    sha256 = "1xd2chx69jdbq2r82d4cgyc8pf1cmmxqvbfz29bf3nvvi6bgq7d5";
+    sha256 = "1fn9xxdszil4zdal08cyq6gbs2larpr4zmjmv2w2ykiacbfhpa6h";
   };
 
   preBuild = ''

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "vault-${version}";
-  version = "1.0.3";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "1c5v1m8b6nm28mjwpsgc73n8q475pkzpdvyx46rf3xyrh01rfrnz";
+    sha256 = "0dylwvs95crvn1p7pbyzib979rxzp4ivzvi5k4f5ivp4ygnp597s";
   };
 
   nativeBuildInputs = [ go gox removeReferencesTo ];
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     ln -s $(pwd) src/github.com/hashicorp/vault
 
     export GOPATH=$(pwd)
+    export GOCACHE="$TMPDIR/go-cache"
   '';
 
   installPhase = ''

--- a/pkgs/tools/security/vault/vault-bin.nix
+++ b/pkgs/tools/security/vault/vault-bin.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, unzip }:
+
+let
+  version = "1.1.3";
+
+  sources = let
+    base = "https://releases.hashicorp.com/vault/${version}";
+  in {
+    "x86_64-linux" = fetchurl {
+      url = "${base}/vault_${version}_linux_amd64.zip";
+      sha256 = "293b88f4d31f6bcdcc8b508eccb7b856a0423270adebfa0f52f04144c5a22ae0";
+    };
+    "i686-linux" = fetchurl {
+      url = "${base}/vault_${version}_linux_386.zip";
+      sha256 = "9f2fb99e08fa3d25af1497516d08b5d2d8a73bcacd5354ddec024e9628795867";
+    };
+    "x86_64-darwin" = fetchurl {
+      url = "${base}/vault_${version}_darwin_amd64.zip";
+      sha256 = "a0a7a242f8299ac4a00af8aa10ccedaf63013c8a068f56eadfb9d730b87155ea";
+    };
+    "i686-darwin" = fetchurl {
+      url = "${base}/vault_${version}_darwin_386.zip";
+      sha256 = "50542cfb37abb06e8bb6b8ba41f5ca7d72a4d6a4396d4e3f4a8391bed14f63be";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "${base}/vault_${version}_linux_arm64.zip";
+      sha256 = "c243dce14b2e48e3667c2aa5b7fb37009dd7043b56032d6ebe50dd456715fd3f";
+    };
+  };
+
+in stdenv.mkDerivation {
+  name = "vault-bin-${version}";
+
+  src = sources."${stdenv.hostPlatform.system}" or (throw "unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/bash-completion/completions
+    mv vault $out/bin
+    echo "complete -C $out/bin/vault vault" > $out/share/bash-completion/completions/vault
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.vaultproject.io;
+    description = "A tool for managing secrets, this binary includes the UI";
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "i686-darwin" ];
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ offline psyanticy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23005,6 +23005,8 @@ in
 
   vault = callPackage ../tools/security/vault { };
 
+  vault-bin = callPackage ../tools/security/vault/vault-bin.nix { };
+
   vaultenv = haskellPackages.vaultenv;
 
   vbam = callPackage ../misc/emulators/vbam {


### PR DESCRIPTION
###### Motivation for this change
Import `vault-bin`, and update `vault` and `consul`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

