### PR TITLE
prometheus: Split options listenAddress and port

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -45,7 +45,7 @@ let
   cmdlineArgs = cfg.extraFlags ++ [
     "--storage.tsdb.path=${workingDir}/data/"
     "--config.file=${prometheusYml}"
-    "--web.listen-address=${cfg.listenAddress}"
+    "--web.listen-address=${cfg.listenAddress}:${builtins.toString cfg.port}"
     "--alertmanager.notification-queue-capacity=${toString cfg.alertmanagerNotificationQueueCapacity}"
     "--alertmanager.timeout=${toString cfg.alertmanagerTimeout}s"
   ] ++
@@ -488,9 +488,17 @@ in {
       '';
     };
 
+    port = mkOption {
+      type = types.int;
+      default = 9090;
+      description = ''
+        Port to listen on.
+      '';
+    };
+
     listenAddress = mkOption {
       type = types.str;
-      default = "0.0.0.0:9090";
+      default = "0.0.0.0";
       description = ''
         Address to listen on for the web interface, API, and telemetry.
       '';


### PR DESCRIPTION
Accessing the configured port of a service is quite useful, for example
when configuring virtual hosts for a service. The prometheus module did
not expose the configured por separately, making it unnecessarily
cumbersome to consume.

This is a breaking change only if you were setting `listenAddress` to
a non-standard value. If you were, you should now set `listenAddress`
and `port` separately.

Maybe there should be an assertion that `listenAddress` does not match `:[0-9]{1,5}$` or similar, so that failure to fix your config is reported at eval time. How does one do that?

Also, apparently GFM doesn't respect the markdown standard of ignoring single linebreaks. Now this description looks stupid.