### PR TITLE
borgbackup: add check service

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -98,6 +98,25 @@ let
       inherit (cfg) startAt;
     };
 
+  mkCheckService = name: cfg: nameValuePair "borgbackup-check-${name}" rec {
+      description = "Check BorgBackup repository ${name}";
+      after = [ "borgbackup-job-${name}" ];
+      conflicts = after;
+      path = with pkgs; [ borgbackup openssh ];
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        CPUSchedulingPolicy = "idle";
+        IOSchedulingClass = "idle";
+        ReadWritePaths = mkIf (isLocalPath cfg.repo) [ cfg.repo ];
+        ExecStart = "${pkgs.borgbackup}/bin/borg check";
+      };
+      environment = {
+        BORG_REPO = cfg.repo;
+      } // (mkPassEnv cfg) // cfg.environment;
+      startAt = "weekly";
+    };
+
   # utility function around makeWrapper
   mkWrapperDrv = {
       original, name, set ? {}
@@ -666,7 +685,9 @@ in {
         # A job named "foo" is mapped to systemd.services.borgbackup-job-foo
         mapAttrs' mkBackupService jobs
         # A repo named "foo" is mapped to systemd.services.borgbackup-repo-foo
-        // mapAttrs' mkRepoService repos;
+        // mapAttrs' mkRepoService repos
+        # A job named "foo" is mapped to systemd.services.borgbackup-check-foo
+        // mapAttrs' mkCheckService jobs;
 
       users = mkMerge (mapAttrsToList mkUsersConfig repos);
 

--- a/nixos/tests/borgbackup.nix
+++ b/nixos/tests/borgbackup.nix
@@ -152,6 +152,8 @@ in {
         client.wait_for_unit("network.target")
         client.systemctl("start --wait borgbackup-job-remote")
         client.fail("systemctl is-failed borgbackup-job-remote")
+        client.systemctl("start --wait borgbackup-check-remote")
+        client.fail("systemctl is-failed borgbackup-check-remote")
 
         # Make sure we can't access repos other than the specified one
         client.fail("{} list borg\@server:wrong".format(borg))


### PR DESCRIPTION
###### Motivation for this change
Routinely verify repo integrity

###### Things done
For each defined job, define a unit and a weekly timer that checks the
associated repo.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
