### PR TITLE
[OPS-1156] nixos/oauth2_proxy_nginx: specify hostname in X-Auth-Request-Redirect

### DIFF
--- a/nixos/modules/services/security/oauth2_proxy_nginx.nix
+++ b/nixos/modules/services/security/oauth2_proxy_nginx.nix
@@ -31,7 +31,7 @@ in
         proxyPass = cfg.proxy;
         extraConfig = ''
           proxy_set_header X-Scheme                $scheme;
-          proxy_set_header X-Auth-Request-Redirect $request_uri;
+          proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
         '';
       };
       locations."/oauth2/auth" = {


### PR DESCRIPTION
Cherry-picked from https://github.com/NixOS/nixpkgs/pull/112391.

Fixes the issue when signing in at one domain redirects you to a different domain.