### PR TITLE
stdenv: trim random seed to avoid reference cycles

### DIFF
--- a/pkgs/build-support/setup-hooks/reproducible-builds.sh
+++ b/pkgs/build-support/setup-hooks/reproducible-builds.sh
@@ -1,4 +1,9 @@
 # Use the last part of the out path as hash input for the build.
 # This should ensure that it is deterministic across rebuilds of the same
 # derivation and not easily collide with other builds.
-export NIX_CFLAGS_COMPILE+=" -frandom-seed=${out##*/}"
+# We also truncate the hash so that it cannot cause reference cycles.
+export NIX_CFLAGS_COMPILE+=" -frandom-seed=$(
+    outbase="${out##*/}"
+    randomseed="${outbase:0:10}"
+    echo $randomseed
+)"


### PR DESCRIPTION
This fix is required for https://github.com/serokell/tezos-packaging, otherwise, reference cycles occur there