### PR TITLE
Revert "stdenv: trim random seed to avoid reference cycles"

### DIFF
--- a/pkgs/build-support/setup-hooks/reproducible-builds.sh
+++ b/pkgs/build-support/setup-hooks/reproducible-builds.sh
@@ -1,9 +1,4 @@
 # Use the last part of the out path as hash input for the build.
 # This should ensure that it is deterministic across rebuilds of the same
 # derivation and not easily collide with other builds.
-# We also truncate the hash so that it cannot cause reference cycles.
-export NIX_CFLAGS_COMPILE+=" -frandom-seed=$(
-    outbase="${out##*/}"
-    randomseed="${outbase:0:10}"
-    echo $randomseed
-)"
+export NIX_CFLAGS_COMPILE+=" -frandom-seed=${out##*/}"


### PR DESCRIPTION
This reverts commit 93c23a92ad7ff55b5c12004f73eeffc7724a0e03.

Cherry pick of 93c23a92ad7ff55b5c12004f73eeffc7724a0e03 causes massive cache misses:(