### PR TITLE
[OPS-1102] buildkite agent concurrency

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agents.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agents.nix
@@ -37,6 +37,23 @@ let
         description = "Whether to enable this buildkite agent";
       };
 
+      count = mkOption {
+        default = 1;
+        type = types.int;
+        description = "How many instances of this agent to start";
+      };
+
+      extraServiceConfig = mkOption {
+        default = {};
+        type = types.attrs;
+        description = "Attributes recursively merged into each unit's serviceConfig";
+        example = literalExample ''
+          {
+            EnvironmentFile = "/run/secrets/buildkite/environment";
+          }
+        '';
+      };
+
       package = mkOption {
         default = pkgs.buildkite-agent;
         defaultText = "pkgs.buildkite-agent";
@@ -215,52 +232,53 @@ in
     "buildkite-agent-${name}" = {};
   });
 
-  config.systemd.services = mapAgents (name: cfg: {
-    "buildkite-agent-${name}" =
-      { description = "Buildkite Agent";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "network.target" ];
-        path = cfg.runtimePackages ++ [ cfg.package pkgs.coreutils ];
-        environment = config.networking.proxy.envVars // {
-          HOME = cfg.dataDir;
-          NIX_REMOTE = "daemon";
-        };
-
-        ## NB: maximum care is taken so that secrets (ssh keys and the CI token)
-        ##     don't end up in the Nix store.
-        preStart = let
-          sshDir = "${cfg.dataDir}/.ssh";
-          tagStr = lib.concatStringsSep "," (lib.mapAttrsToList (name: value: "${name}=${value}") cfg.tags);
-        in
-          optionalString (cfg.privateSshKeyPath != null) ''
-            mkdir -m 0700 -p "${sshDir}"
-            cp -f "${toString cfg.privateSshKeyPath}" "${sshDir}/id_rsa"
-            chmod 600 "${sshDir}"/id_rsa
-          '' + ''
-            cat > "${cfg.dataDir}/buildkite-agent.cfg" <<EOF
-            token="$(cat ${toString cfg.tokenPath})"
-            name="${cfg.name}"
-            shell="${cfg.shell}"
-            tags="${tagStr}"
-            build-path="${cfg.dataDir}/builds"
-            plugins-path="${cfg.dataDir}/plugins"
-            hooks-path="${cfg.hooksPath}"
-            ${cfg.extraConfig}
-            EOF
-          '';
-
-        serviceConfig =
-          { ExecStart = "${cfg.package}/bin/buildkite-agent start --config ${cfg.dataDir}/buildkite-agent.cfg";
-            User = "buildkite-agent-${name}";
-            RestartSec = 5;
-            Restart = "on-failure";
-            TimeoutSec = 10;
-            # set a long timeout to give buildkite-agent a chance to finish current builds
-            TimeoutStopSec = "2 min";
-            KillMode = "mixed";
+  config.systemd.services = mapAgents (name: cfg:
+    mkMerge ((flip map) (range 1 cfg.count) (n: {
+      "buildkite-agent-${name}-${toString n}" =
+        { description = "Buildkite Agent";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network.target" ];
+          path = cfg.runtimePackages ++ [ cfg.package pkgs.coreutils ];
+          environment = config.networking.proxy.envVars // {
+            HOME = cfg.dataDir;
+            NIX_REMOTE = "daemon";
           };
-      };
-  });
+
+          ## NB: maximum care is taken so that secrets (ssh keys and the CI token)
+          ##     don't end up in the Nix store.
+          preStart = let
+            sshDir = "${cfg.dataDir}/.ssh";
+            tagStr = lib.concatStringsSep "," (lib.mapAttrsToList (name: value: "${name}=${value}") cfg.tags);
+          in
+            optionalString (cfg.privateSshKeyPath != null) ''
+              mkdir -m 0700 -p "${sshDir}"
+              cp -f "${toString cfg.privateSshKeyPath}" "${sshDir}/id_rsa"
+              chmod 600 "${sshDir}"/id_rsa
+            '' + ''
+              cat > "${cfg.dataDir}/buildkite-agent.cfg" <<EOF
+              token="$(cat ${toString cfg.tokenPath})"
+              name="${cfg.name}-${toString n}"
+              shell="${cfg.shell}"
+              tags="${tagStr}"
+              build-path="${cfg.dataDir}/builds"
+              plugins-path="${cfg.dataDir}/plugins"
+              hooks-path="${cfg.hooksPath}"
+              ${cfg.extraConfig}
+              EOF
+            '';
+
+          serviceConfig =
+            { ExecStart = "${cfg.package}/bin/buildkite-agent start --config ${cfg.dataDir}/buildkite-agent.cfg";
+              User = "buildkite-agent-${name}";
+              RestartSec = 5;
+              Restart = "on-failure";
+              TimeoutSec = 10;
+              # set a long timeout to give buildkite-agent a chance to finish current builds
+              TimeoutStopSec = "2 min";
+              KillMode = "mixed";
+            } // cfg.extraServiceConfig;
+        };
+    })));
 
   config.assertions = mapAgents (name: cfg: [
       { assertion = cfg.hooksPath == (hooksDir cfg) || all (v: v == null) (attrValues cfg.hooks);

--- a/nixos/tests/buildkite-agents.nix
+++ b/nixos/tests/buildkite-agents.nix
@@ -1,6 +1,8 @@
 import ./make-test-python.nix ({ pkgs, ... }:
 
-{
+let
+  envFile = pkgs.writeText "environment" "FOO=bar";
+in {
   name = "buildkite-agent";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ flokli ];
@@ -15,6 +17,11 @@ import ./make-test-python.nix ({ pkgs, ... }:
       two = {
         tokenPath = (pkgs.writeText "my-token" "1234");
       };
+      concurrent = {
+        tokenPath = (pkgs.writeText "my-token" "9123");
+        extraServiceConfig.EnvironmentFile = "${envFile}";
+        count = 8;
+      };
     };
   };
 
@@ -27,5 +34,16 @@ import ./make-test-python.nix ({ pkgs, ... }:
     machine.wait_for_file("/var/lib/buildkite-agent-one/.ssh/id_rsa")
 
     machine.wait_for_file("/var/lib/buildkite-agent-two/buildkite-agent.cfg")
+
+    machine.wait_for_file("/var/lib/buildkite-agent-concurrent/buildkite-agent.cfg")
+
+    # Make sure all 8 concurrent agent units exist and have the environment file set
+    for n in range(1, 8):
+        i = machine.get_unit_info("buildkite-agent-concurrent-{}".format(n))
+        assert (
+            "${envFile}"
+            in i["EnvironmentFiles"]
+        )
+        assert i["LoadState"] == "loaded"
   '';
 })


### PR DESCRIPTION
This is a fairly naive implementation, in accordance to the official docs: https://buildkite.com/docs/tutorials/parallel-builds#running-multiple-agents

You can specify a `count` option for an agent, and it will just create additional systemd units. Same user, same state folder, etc. Buildkite swear this is fine, but obviously we need to take care that tests that can run at the same time don't also try to use the same database at the same time and such.