### PR TITLE
Mkaito/edna117 docker env file

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -59,6 +59,13 @@ let
         '';
         };
 
+        environmentFile = mkOption {
+          type = with types; str;
+          default = {};
+          description = "Read in a file of environment variables.";
+          example = "/var/run/secrets/docker/backend.env";
+        };
+
         log-driver = mkOption {
           type = types.str;
           default = "journald";
@@ -236,6 +243,7 @@ let
     ] ++ optional (container.entrypoint != null)
       "--entrypoint=${escapeShellArg container.entrypoint}"
       ++ (mapAttrsToList (k: v: "-e ${escapeShellArg k}=${escapeShellArg v}") container.environment)
+      ++ "--env-file=${escapeShellArg container.environmentFile}"
       ++ map (p: "-p ${escapeShellArg p}") container.ports
       ++ optional (container.user != null) "-u ${escapeShellArg container.user}"
       ++ map (v: "-v ${escapeShellArg v}") container.volumes


### PR DESCRIPTION

Allow passing environment files to a container.

I'm actually not 100% whether this should be `str` or `path`. It's obviously semantically a `path`, but I also don't want it in the nix store, and I think `path` gets stored?