### PR TITLE
[OPS-1269] youtrack: switch to jdk11 to fix the service

### DIFF
--- a/pkgs/servers/jetbrains/youtrack.nix
+++ b/pkgs/servers/jetbrains/youtrack.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, jre, gawk }:
+{ lib, stdenv, fetchurl, makeWrapper, jdk11, gawk }:
 
 stdenv.mkDerivation rec {
   pname = "youtrack";
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    makeWrapper ${jre}/bin/java $out/bin/youtrack \
+    makeWrapper ${jdk11}/bin/java $out/bin/youtrack \
       --add-flags "\$YOUTRACK_JVM_OPTS -jar $jar" \
       --prefix PATH : "${lib.makeBinPath [ gawk ]}" \
-      --set JRE_HOME ${jre}
+      --set JRE_HOME ${jdk11}
     runHook postInstall
   '';
 


### PR DESCRIPTION
Fixes YouTrack, cherry-picked from https://github.com/NixOS/nixpkgs/pull/138124