### PR TITLE
Revert "docker.nix: Add options for named volumes and networks"

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -10,68 +10,6 @@ let
   proxy_env = config.networking.proxy.envVars;
   settingsFormat = pkgs.formats.json {};
   daemonSettingsFile = settingsFormat.generate "daemon.json" cfg.daemon.settings;
-
-  inherit (builtins) attrNames;
-
-  mkUncreateMaybe = networks: volumes: ''
-    set -euo pipefail
-
-    nexisting=$(${pkgs.coreutils}/bin/mktemp)
-    nwanted=$(${pkgs.coreutils}/bin/mktemp)
-    vexisting=$(${pkgs.coreutils}/bin/mktemp)
-    vwanted=$(${pkgs.coreutils}/bin/mktemp)
-
-    cleanup() {
-      rm -f "$nexisting" "$nwanted" "$vexisting" "$vwanted"
-    }
-    trap cleanup EXIT
-
-    ${pkgs.docker}/bin/docker network ls --format '{{.Name}}' > "$nexisting"
-    echo -e "bridge\nhost\nnone\n${concatStringsSep "\n" networks}" > "$nwanted"
-
-    ${pkgs.docker}/bin/docker volume ls --format '{{.Name}}' > "$vexisting"
-    echo -e "${concatStringsSep "\n" volumes}" > "$vwanted"
-
-    nsuperfluous="$(${pkgs.gnugrep}/bin/grep -vxF -f $nwanted $nexisting || true)"
-    vsuperfluous="$(${pkgs.gnugrep}/bin/grep -vxF -f $vwanted $vexisting || true)"
-
-    while read -r net; do
-      if [[ ! -z "$net" ]]; then
-        echo -n "Removed superfluous Docker network: "
-        ${pkgs.docker}/bin/docker network rm "$net" || true
-      fi
-    done <<< "$nsuperfluous"
-
-    while read -r vol; do
-      if [[ ! -z "$vol" ]]; then
-        echo -n "Removed superfluous Docker volume: "
-        ${pkgs.docker}/bin/docker volume rm "$vol" || true
-      fi
-    done <<< "$vsuperfluous"
-  '';
-
-  mkNetworkOpts = opts: concatStringsSep " "
-    ([ "--driver=${opts.driver}" ]
-    ++ optional (cfg ? subnet && cfg.subnet != null) "--subnet=${opts.subnet}"
-    ++ optional (cfg ? ip-range && cfg.ip-range != null) "--ip-range=${opts.ip-range}"
-    ++ optional (cfg ? gateway && cfg.gateway != null) "--gateway=${opts.gateway}"
-    ++ optional (cfg ? ipv6 && cfg.ipv6) "--ipv6"
-    ++ optional (cfg ? internal && cfg.internal) "--internal");
-
-
-  mkNetwork = name: opts: ''
-    if [[ $(${pkgs.docker}/bin/docker network ls --quiet --filter name=${name} | wc -c) -eq 0 ]]; then
-      echo "*** docker network create ${mkNetworkOpts opts} ${name}"
-      ${pkgs.docker}/bin/docker network create ${mkNetworkOpts opts} ${name}
-    fi
-  '';
-
-  mkVolume = name: ''
-    if [[ $(${pkgs.docker}/bin/docker volume ls --quiet --filter name=${name} | wc -c) -eq 0 ]]; then
-      echo "*** docker volume create ${name}"
-      ${pkgs.docker}/bin/docker volume create ${name}
-    fi
-  '';
 in
 
 {
@@ -170,16 +108,6 @@ in
           '';
       };
 
-    logLevel =
-      mkOption {
-        type = types.enum ["debug" "info" "warn" "error" "fatal"];
-        default = "info";
-        description =
-          ''
-            This option determines the log level for the Docker daemon.
-          '';
-      };
-
     extraOptions =
       mkOption {
         type = types.separatedString " ";
@@ -232,89 +160,6 @@ in
         Extra packages to add to PATH for the docker daemon process.
       '';
     };
-
-    volumes = mkOption {
-      default = [];
-      type = types.listOf types.str;
-      example = [ "volume_1" "volume_2" ];
-      description = ''
-        A list of named volumes that should be created.
-      '';
-    };
-
-    networks = mkOption {
-      default = {};
-      type = types.attrsOf (types.submodule {
-        options = {
-          driver = mkOption {
-            default = "bridge";
-            type = types.str;
-            example = "overlay";
-            description = ''
-              Driver to manage the network. One of bridge, or overlay.
-            '';
-          };
-
-          subnet = mkOption {
-            default = null;
-            type = types.nullOr types.str;
-            example = "172.28.0.0/16";
-            description = ''
-              Subnet in CIDR format that represents a network segment.
-            '';
-          };
-
-          ip-range = mkOption {
-            default = null;
-            type = types.nullOr types.str;
-            example = "172.28.5.0/24";
-            description = ''
-              Allocate container ip from a sub-range.
-            '';
-          };
-
-          gateway = mkOption {
-            default = null;
-            type = types.nullOr types.str;
-            example = "172.28.5.254";
-            description = ''
-              IPv4 or IPv6 Gateway for the master subnet.
-            '';
-          };
-
-          ipv6 = mkOption {
-            default = false;
-            type = types.bool;
-            example = true;
-            description = ''
-              Enable IPv6 networking.
-            '';
-          };
-
-          internal = mkOption {
-            default = false;
-            type = types.bool;
-            example = true;
-            description = ''
-              Restrict external access to the network.
-            '';
-          };
-        };
-      });
-
-      example = {
-        my-network = {
-          driver = "bridge";
-          subnet = "172.28.0.0/16";
-          ip-range = "172.28.5.0/24";
-          gateway = "172.28.5.254";
-        };
-      };
-
-      description = ''
-        A list of named networks to be created.
-      '';
-    };
   };
 
   ###### implementation
@@ -335,11 +180,6 @@ in
         after = [ "network.target" "docker.socket" ];
         requires = [ "docker.socket" ];
         environment = proxy_env;
-
-        postStart = mkUncreateMaybe (attrNames cfg.networks) cfg.volumes
-                  + concatStrings (mapAttrsToList mkNetwork cfg.networks)
-                  + concatStrings (map mkVolume cfg.volumes);
-
         serviceConfig = {
           Type = "notify";
           ExecStart = [
@@ -347,10 +187,8 @@ in
             ''
               ${cfg.package}/bin/dockerd \
                 --config-file=${daemonSettingsFile} \
-                --log-level=${cfg.logLevel} \
                 ${cfg.extraOptions}
             ''];
-
           ExecReload=[
             ""
             "${pkgs.procps}/bin/kill -s HUP $MAINPID"

--- a/nixos/tests/docker.nix
+++ b/nixos/tests/docker.nix
@@ -10,19 +10,9 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     docker =
       { pkgs, ... }:
         {
-          virtualisation.docker = {
-            enable = true;
-            package = pkgs.docker;
-            volumes = [ "thevolume" ];
-            networks.thenetwork = {
-              driver = "bridge";
-              subnet = "172.28.0.0/16";
-              ip-range = "172.28.5.0/24";
-              gateway = "172.28.5.254";
-            };
-
-            logLevel = "warn";
-          };
+          virtualisation.docker.enable = true;
+          virtualisation.docker.autoPrune.enable = true;
+          virtualisation.docker.package = pkgs.docker;
 
           users.users = {
             noprivs = {
@@ -53,15 +43,6 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     docker.succeed("sudo -u hasprivs docker ps")
     docker.fail("sudo -u noprivs docker ps")
     docker.succeed("docker stop sleeping")
-
-    $docker->succeed("docker volume ls | grep thevolume");
-    $docker->succeed("docker network ls | grep thenetwork");
-
-    $docker->succeed("docker volume create superfluousvolume");
-    $docker->succeed("docker network create superfluousnetwork");
-    $docker->systemctl("restart docker");
-    $docker->waitForUnit("docker.service");
-    $docker->fail("docker volume ls | grep superfluous");
 
     # Must match version 4 times to ensure client and server git commits and versions are correct
     docker.succeed('[ $(docker version | grep ${pkgs.docker.version} | wc -l) = "4" ]')


### PR DESCRIPTION


This reverts commit 4f5445aa6317f5f1aa67cecc35cd5c6207f50f9b.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
